### PR TITLE
Lec44のURL変更

### DIFF
--- a/Lec044.ipynb
+++ b/Lec044.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -30,8 +30,11 @@
    },
    "outputs": [],
    "source": [
-    "# サンプルデータは、次のURLからダウンロードできます。\n",
-    "url = 'http://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/'"
+    "# 2024年11月の時点で動画のURLが使えなくなってしまいまいました。\n",
+    "# データの配布元は以下のURLなので、こちらからzipファイルをダウンロードして解凍してもwinequality-red.csvを入手できます。\n",
+    "# https://archive.ics.uci.edu/dataset/186/wine+quality\n",
+    "# 私が管理するWebサーバにも置いてあるので、こちらから直接ダウンロードすることも可能です。\n",
+    "url = \"https://www.tsjshg.info/udemy2/winequality-red.csv\""
    ]
   },
   {
@@ -1485,7 +1488,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "ds3.12",
    "language": "python",
    "name": "python3"
   },
@@ -1499,7 +1502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 2024年11月の時点で動画のURLが使えなくなってしまいまいました。データの配布元は以下のURLなので、こちらからzipファイルをダウンロードして解凍してもwinequality-red.csvを入手できます。
[https://archive.ics.uci.edu/dataset/186/wine+quality](https://archive.ics.uci.edu/dataset/186/wine+quality)

私が管理するWebサーバにも置いてあるので、こちらから直接ダウンロードすることも可能です。
[https://www.tsjshg.info/udemy2/winequality-red.csv](https://www.tsjshg.info/udemy2/winequality-red.csv)